### PR TITLE
Fix OAuth integration issues

### DIFF
--- a/client/src/components/transactions/PlaidConnectionDialog.tsx
+++ b/client/src/components/transactions/PlaidConnectionDialog.tsx
@@ -179,7 +179,7 @@ export default function PlaidConnectionDialog({ isOpen, onClose }: PlaidConnecti
         console.log(`Plaid Link successful - Connected to: ${bankName}`);
         
         // Get accounts for the connected bank
-        const accountsResponse = await apiRequest('POST', '/api/plaid/accounts', {});
+        const accountsResponse = await apiRequest('GET', '/api/plaid/accounts');
         
         // Invalidate any cached account data
         queryClient.invalidateQueries({ queryKey: ['/api/accounts'] });

--- a/server/controllers-ts/googleAuthController.ts
+++ b/server/controllers-ts/googleAuthController.ts
@@ -61,7 +61,7 @@ export const googleCallback = [
       const cookieOptions = {
         httpOnly: true,
         secure: isProduction, // Use secure cookies in production
-        sameSite: 'lax' as const, // CRITICAL: Use 'lax' for OAuth redirects
+        sameSite: isProduction ? 'none' as const : 'lax' as const, // allow cross-site OAuth redirects
         maxAge: JWT_EXPIRY * 1000,
         path: '/' // Ensure cookie is available site-wide
       };
@@ -86,12 +86,18 @@ export const googleCallback = [
       
       console.log('Google OAuth: Session created, redirecting to dashboard with auth token');
       
-      // CRITICAL: Call req.login() to establish Passport session
-      req.login(user, (loginError) => {
-        if (loginError) {
-          console.error('Google OAuth: Failed to establish session:', loginError);
-          return res.redirect('/auth?error=session_error');
+      // Regenerate session to avoid fixation and then establish Passport session
+      req.session.regenerate((regenError) => {
+        if (regenError) {
+          console.error('Google OAuth: Session regenerate error:', regenError);
         }
+
+        // Establish Passport session
+        req.login(user, (loginError) => {
+          if (loginError) {
+            console.error('Google OAuth: Failed to establish session:', loginError);
+            return res.redirect('/auth?error=session_error');
+          }
         
         console.log('Google OAuth: Session established for user ID:', user.id);
         console.log('Google OAuth: User details:', {
@@ -125,9 +131,10 @@ export const googleCallback = [
             lastName: user.lastName
           }));
           
-          res.redirect(`/dashboard?auth=${authParam}&user=${userParam}`);
+        res.redirect(`/dashboard?auth=${authParam}&user=${userParam}`);
         });
       });
+    });
       
     } catch (error) {
       console.error('Google OAuth callback error:', error);


### PR DESCRIPTION
## Summary
- correct Plaid account retrieval call on frontend
- tweak Google OAuth callback cookies and regenerate session to ensure login

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683f8a18bc84833297df2709870e55c8